### PR TITLE
Rectified bug for SafeSearchAnnotation Mapping

### DIFF
--- a/cloudvisionlib/src/main/java/net/trippedout/cloudvisionlib/CloudVisionApi.java
+++ b/cloudvisionlib/src/main/java/net/trippedout/cloudvisionlib/CloudVisionApi.java
@@ -280,7 +280,7 @@ public class CloudVisionApi {
                     mResponseMap.put(FEATURE_TYPE_IMAGE_PROPERTIES, response);
                 if (response instanceof FaceDetectResponse)
                     mResponseMap.put(FEATURE_TYPE_FACE_DETECTION, response);
-                if (response instanceof LabelResponse)
+                if (response instanceof SafeSearchResponse)
                     mResponseMap.put(FEATURE_TYPE_SAFE_SEARCH_DETECTION, response);
             }
         }


### PR DESCRIPTION
FEATURE_TYPE_SAFE_SEARCH_DETECTION type was mapped to wrong type of Response. It is now rectified.
